### PR TITLE
Add Polyphony (Mininglamp) to CL-bench leaderboard

### DIFF
--- a/clb.css
+++ b/clb.css
@@ -241,6 +241,7 @@
 .clb-bar-MiniMax    { background: #7c3aed; }
 .clb-bar-Zhipu      { background: #0ea5e9; }
 .clb-bar-Xiaomi     { background: #ff6900; }
+.clb-bar-Mininglamp { background: #1E5096; }
 
 /* Expand row */
 .clb-expand-btn {

--- a/data/clb-data.json
+++ b/data/clb-data.json
@@ -33,5 +33,6 @@
   { "model": "Doubao 1.6", "org": "ByteDance", "overall": 0.131, "overall_std": 0.001, "domain": 0.119, "domain_std": 0.005, "rule": 0.147, "rule_std": 0.007, "procedural": 0.151, "procedural_std": 0.005, "pattern": 0.079, "pattern_std": 0.008 },
   { "model": "DeepSeek V3.2", "org": "DeepSeek", "overall": 0.124, "overall_std": 0.005, "domain": 0.123, "domain_std": 0.008, "rule": 0.134, "rule_std": 0.010, "procedural": 0.135, "procedural_std": 0.004, "pattern": 0.070, "pattern_std": 0.005 },
   { "model": "Kimi K2", "org": "Moonshot", "overall": 0.119, "overall_std": 0.005, "domain": 0.123, "domain_std": 0.011, "rule": 0.127, "rule_std": 0.005, "procedural": 0.132, "procedural_std": 0.011, "pattern": 0.057, "pattern_std": 0.008 },
-  { "model": "MiniMax M2.5", "org": "MiniMax", "overall": 0.114, "overall_std": 0, "domain": 0.122, "domain_std": 0, "rule": 0.106, "rule_std": 0, "procedural": 0.137, "procedural_std": 0, "pattern": 0.051, "pattern_std": 0 }
+  { "model": "MiniMax M2.5", "org": "MiniMax", "overall": 0.114, "overall_std": 0, "domain": 0.122, "domain_std": 0, "rule": 0.106, "rule_std": 0, "procedural": 0.137, "procedural_std": 0, "pattern": 0.051, "pattern_std": 0 },
+  { "model": "Polyphony", "org": "Mininglamp", "overall": 0.234, "overall_std": 0.004, "domain": 0.251, "domain_std": 0.010, "rule": 0.227, "rule_std": 0.005, "procedural": 0.267, "procedural_std": 0.009, "pattern": 0.117, "pattern_std": 0.006 }
 ]

--- a/index.html
+++ b/index.html
@@ -513,6 +513,7 @@
               <button class="clb-filter" data-org="Tencent">Tencent</button>
               <button class="clb-filter" data-org="Zhipu">Zhipu</button>
               <button class="clb-filter" data-org="Xiaomi">Xiaomi</button>
+              <button class="clb-filter" data-org="Mininglamp">Mininglamp</button>
             </div>
             <div class="clb-filters clb-reasoning-filters">
               <button class="clb-filter clb-reason-filter active" data-reason="all">All</button>


### PR DESCRIPTION
## Submission

Adding a new entry to the CL-bench leaderboard following the submission guide in the `gh-pages` README.

### Model Info
- **Model**: Polyphony
- **Organization**: Mininglamp
- **Evaluation**: N=3 runs on the full 1899 tasks

### Scores
| Metric | Value | Std |
|---|---|---|
| Overall     | 0.234 | 0.004 |
| Domain      | 0.251 | 0.010 |
| Rule        | 0.227 | 0.005 |
| Procedural  | 0.267 | 0.009 |
| Empirical   | 0.117 | 0.006 |

### Styling & UI additions
To make the new org render correctly and be filterable, this PR also:
- Adds `.clb-bar-Mininglamp { background: #1E5096; }` in `clb.css`.
- Adds a `Mininglamp` button to the CL-bench leaderboard org filter in `index.html` (consistent with the existing 12 org buttons).

### Reproducibility
Full graded-output JSONL files (3 runs) are published as a GitHub Release
(they exceed the 100MB upload limit on PRs):

👉 **https://github.com/ruiyangy/CL-bench/releases/tag/grading**